### PR TITLE
Update build command for release-pipeline

### DIFF
--- a/.github/workflows/release-pipeline.yaml
+++ b/.github/workflows/release-pipeline.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Run linter
         run: npm run lint
       - name: Build the library
-        run: npm run build:lib
+        run: npm run build
       - name: Publish to NPM
         run: npm run dopublish
         env:


### PR DESCRIPTION
Lib build command was changed to `npm run build`. Forgot to update that in the release-pipeline workflow.