### PR TITLE
Add "repository" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
   "author": "Freshworks Inc",
   "license": "MIT",
   "homepage": "https://developers.freshworks.com/api-sdk/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/freshworks/freshworks-api-sdk.git"
+  },
   "keywords": [
     "freshworks",
     "freshteam",


### PR DESCRIPTION
Linked to public repo in `package.json`.