### PR TITLE
Use freshworks.dev URL in homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "author": "Freshworks Inc",
   "license": "MIT",
-  "homepage": "https://developers.freshworks.com/api-sdk/",
+  "homepage": "https://freshworks.dev/api-sdk/",
   "repository": {
     "type": "git",
     "url": "https://github.com/freshworks/freshworks-api-sdk.git"


### PR DESCRIPTION
Use `freshworks.dev` URL in the homepage field.