### PR TITLE
Fix dependency vulnerability from vuepress

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@freshworks/api-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1224,53 +1224,53 @@
       }
     },
     "@vitejs/plugin-vue": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.1.0.tgz",
-      "integrity": "sha512-AZ78WxvFMYd8JmM/GBV6a6SGGTU0GgN/0/4T+FnMMsLzFEzTeAUwuraapy50ifHZsC+G5SvWs86bvaCPTneFlA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.2.4.tgz",
+      "integrity": "sha512-ev9AOlp0ljCaDkFZF3JwC/pD2N4Hh+r5srl5JHM6BKg5+99jiiK0rE/XaRs3pVm1wzyKkjUy/StBSoXX5fFzcw==",
       "dev": true
     },
     "@vue/compiler-core": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.29.tgz",
-      "integrity": "sha512-RePZ/J4Ub3sb7atQw6V6Rez+/5LCRHGFlSetT3N4VMrejqJnNPXKUt5AVm/9F5MJriy2w/VudEIvgscCfCWqxw==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.31.tgz",
+      "integrity": "sha512-aKno00qoA4o+V/kR6i/pE+aP+esng5siNAVQ422TkBNM6qA4veXiZbSe8OTXHXquEi/f6Akc+nLfB4JGfe4/WQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.29",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "source-map": "^0.6.1"
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-          "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+          "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
           "dev": true
         }
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.29.tgz",
-      "integrity": "sha512-y26vK5khdNS9L3ckvkqJk/78qXwWb75Ci8iYLb67AkJuIgyKhIOcR1E8RIt4mswlVCIeI9gQ+fmtdhaiTAtrBQ==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.31.tgz",
+      "integrity": "sha512-60zIlFfzIDf3u91cqfqy9KhCKIJgPeqxgveH2L+87RcGU/alT6BRrk5JtUso0OibH3O7NXuNOQ0cDc9beT0wrg==",
       "dev": true,
       "requires": {
-        "@vue/compiler-core": "3.2.29",
-        "@vue/shared": "3.2.29"
+        "@vue/compiler-core": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.29.tgz",
-      "integrity": "sha512-X9+0dwsag2u6hSOP/XsMYqFti/edvYvxamgBgCcbSYuXx1xLZN+dS/GvQKM4AgGS4djqo0jQvWfIXdfZ2ET68g==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.31.tgz",
+      "integrity": "sha512-748adc9msSPGzXgibHiO6T7RWgfnDcVQD+VVwYgSsyyY8Ans64tALHZANrKtOzvkwznV/F4H7OAod/jIlp/dkQ==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.29",
-        "@vue/compiler-dom": "3.2.29",
-        "@vue/compiler-ssr": "3.2.29",
-        "@vue/reactivity-transform": "3.2.29",
-        "@vue/shared": "3.2.29",
+        "@vue/compiler-core": "3.2.31",
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/compiler-ssr": "3.2.31",
+        "@vue/reactivity-transform": "3.2.31",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7",
         "postcss": "^8.1.10",
@@ -1278,107 +1278,107 @@
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-          "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+          "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
           "dev": true
         }
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.29.tgz",
-      "integrity": "sha512-LrvQwXlx66uWsB9/VydaaqEpae9xtmlUkeSKF6aPDbzx8M1h7ukxaPjNCAXuFd3fUHblcri8k42lfimHfzMICA==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.31.tgz",
+      "integrity": "sha512-mjN0rqig+A8TVDnsGPYJM5dpbjlXeHUm2oZHZwGyMYiGT/F4fhJf/cXy8QpjnLQK4Y9Et4GWzHn9PS8AHUnSkw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.2.29",
-        "@vue/shared": "3.2.29"
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "@vue/devtools-api": {
-      "version": "6.0.0-beta.21.1",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.21.1.tgz",
-      "integrity": "sha512-FqC4s3pm35qGVeXRGOjTsRzlkJjrBLriDS9YXbflHLsfA9FrcKzIyWnLXoNm+/7930E8rRakXuAc2QkC50swAw==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.12.tgz",
+      "integrity": "sha512-iO/4FIezHKXhiDBdKySCvJVh8/mZPxHpiQrTy+PXVqJZgpTPTdHy4q8GXulaY+UKEagdkBb0onxNQZ0LNiqVhw==",
       "dev": true
     },
     "@vue/reactivity": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.29.tgz",
-      "integrity": "sha512-Ryhb6Gy62YolKXH1gv42pEqwx7zs3n8gacRVZICSgjQz8Qr8QeCcFygBKYfJm3o1SccR7U+bVBQDWZGOyG1k4g==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.31.tgz",
+      "integrity": "sha512-HVr0l211gbhpEKYr2hYe7hRsV91uIVGFYNHj73njbARVGHQvIojkImKMaZNDdoDZOIkMsBc9a1sMqR+WZwfSCw==",
       "dev": true,
       "requires": {
-        "@vue/shared": "3.2.29"
+        "@vue/shared": "3.2.31"
       }
     },
     "@vue/reactivity-transform": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.29.tgz",
-      "integrity": "sha512-YF6HdOuhdOw6KyRm59+3rML8USb9o8mYM1q+SH0G41K3/q/G7uhPnHGKvspzceD7h9J3VR1waOQ93CUZj7J7OA==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.31.tgz",
+      "integrity": "sha512-uS4l4z/W7wXdI+Va5pgVxBJ345wyGFKvpPYtdSgvfJfX/x2Ymm6ophQlXXB6acqGHtXuBqNyyO3zVp9b1r0MOA==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.29",
-        "@vue/shared": "3.2.29",
+        "@vue/compiler-core": "3.2.31",
+        "@vue/shared": "3.2.31",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.25.7"
       },
       "dependencies": {
         "@babel/parser": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.0.tgz",
-          "integrity": "sha512-VKXSCQx5D8S04ej+Dqsr1CzYvvWgf20jIw2D+YhQCrIlr2UZGaDds23Y0xg75/skOxpLCRpUZvk/1EAVkGoDOw==",
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+          "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
           "dev": true
         }
       }
     },
     "@vue/runtime-core": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.29.tgz",
-      "integrity": "sha512-VMvQuLdzoTGmCwIKTKVwKmIL0qcODIqe74JtK1pVr5lnaE0l25hopodmPag3RcnIcIXe+Ye3B2olRCn7fTCgig==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.31.tgz",
+      "integrity": "sha512-Kcog5XmSY7VHFEMuk4+Gap8gUssYMZ2+w+cmGI6OpZWYOEIcbE0TPzzPHi+8XTzAgx1w/ZxDFcXhZeXN5eKWsA==",
       "dev": true,
       "requires": {
-        "@vue/reactivity": "3.2.29",
-        "@vue/shared": "3.2.29"
+        "@vue/reactivity": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.29.tgz",
-      "integrity": "sha512-YJgLQLwr+SQyORzTsBQLL5TT/5UiV83tEotqjL7F9aFDIQdFBTCwpkCFvX9jqwHoyi9sJqM9XtTrMcc8z/OjPA==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.31.tgz",
+      "integrity": "sha512-N+o0sICVLScUjfLG7u9u5XCjvmsexAiPt17GNnaWHJUfsKed5e85/A3SWgKxzlxx2SW/Hw7RQxzxbXez9PtY3g==",
       "dev": true,
       "requires": {
-        "@vue/runtime-core": "3.2.29",
-        "@vue/shared": "3.2.29",
+        "@vue/runtime-core": "3.2.31",
+        "@vue/shared": "3.2.31",
         "csstype": "^2.6.8"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.29.tgz",
-      "integrity": "sha512-lpiYx7ciV7rWfJ0tPkoSOlLmwqBZ9FTmQm33S+T4g0j1fO/LmhJ9b9Ctl1o5xvIFVDk9QkSUWANZn7H2pXuxVw==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.31.tgz",
+      "integrity": "sha512-8CN3Zj2HyR2LQQBHZ61HexF5NReqngLT3oahyiVRfSSvak+oAvVmu8iNLSu6XR77Ili2AOpnAt1y8ywjjqtmkg==",
       "dev": true,
       "requires": {
-        "@vue/compiler-ssr": "3.2.29",
-        "@vue/shared": "3.2.29"
+        "@vue/compiler-ssr": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "@vue/shared": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.29.tgz",
-      "integrity": "sha512-BjNpU8OK6Z0LVzGUppEk0CMYm/hKDnZfYdjSmPOs0N+TR1cLKJAkDwW8ASZUvaaSLEi6d3hVM7jnWnX+6yWnHw==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.31.tgz",
+      "integrity": "sha512-ymN2pj6zEjiKJZbrf98UM2pfDd6F2H7ksKw7NDt/ZZ1fh5Ei39X5tABugtT03ZRlWd9imccoK0hE8hpjpU7irQ==",
       "dev": true
     },
     "@vuepress/bundler-vite": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/bundler-vite/-/bundler-vite-2.0.0-beta.35.tgz",
-      "integrity": "sha512-U8u7t9dDRxoh5MV++ntQUJUsofennBla+8weca+C2LEhSqzlqaDvqCsmVI0sc5vipBDfSWvwNqCb+cRTdlXirw==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/bundler-vite/-/bundler-vite-2.0.0-beta.36.tgz",
+      "integrity": "sha512-wIWbBhLtGotQ1zJGkCHFllKmmpqG2FhcIhoUPY8/VESOmKyUrE6Mbbsk5g8Un0kFbhiF3eFYP1eUxbZttbbpkA==",
       "dev": true,
       "requires": {
         "@vitejs/plugin-vue": "^2.1.0",
         "@vue/compiler-sfc": "^3.2.28",
         "@vue/server-renderer": "^3.2.28",
         "@vuepress/client": "2.0.0-beta.35",
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "@vuepress/shared": "2.0.0-beta.35",
         "@vuepress/utils": "2.0.0-beta.35",
         "autoprefixer": "^10.4.2",
@@ -1404,13 +1404,13 @@
       }
     },
     "@vuepress/core": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.35.tgz",
-      "integrity": "sha512-EWcO/C+VgYl/i4o5arfKeasvtRUgHBe/fNqiDwTGysJVlez6brH1TvViTPth1nAXi+YZeJ6C2LCuH7gCU6Wh+w==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.36.tgz",
+      "integrity": "sha512-RBj2Tkgt2f7NMCfox1iKgd6V87X5qj8G/cpJm7R65IielaXkNGGKjgidOrLKRCA3X0c/COwmaBrdiFxJtOtIRw==",
       "dev": true,
       "requires": {
         "@vuepress/client": "2.0.0-beta.35",
-        "@vuepress/markdown": "2.0.0-beta.35",
+        "@vuepress/markdown": "2.0.0-beta.36",
         "@vuepress/shared": "2.0.0-beta.35",
         "@vuepress/utils": "2.0.0-beta.35",
         "gray-matter": "^4.0.3",
@@ -1418,9 +1418,9 @@
       }
     },
     "@vuepress/markdown": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.35.tgz",
-      "integrity": "sha512-fVg3UlQ86eaUXVHMW3SSZwSkaQvdx1CbGmsl3nZ/FZ3FbEIhHUeaZmLcNiaI3y8P4ORH/Nhit17gtcDCc6yPNg==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.36.tgz",
+      "integrity": "sha512-Amvo7YuSbMZIfj24kwXDen81RsjliXTDvhv+R14aH4NbH9rpwKzTTtbmjWH6O/upqikDYIXhlozHjr1nEf1qHw==",
       "dev": true,
       "requires": {
         "@types/markdown-it": "^12.2.3",
@@ -1433,13 +1433,13 @@
       }
     },
     "@vuepress/plugin-active-header-links": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-2.0.0-beta.35.tgz",
-      "integrity": "sha512-TQJqoIpRBFaohu7wHdwUrUkubA6S58MGDI8MkfkEFEN+fDarUEUOpWC3AIZUYbHTAJp1qRCRl4ZEB85xvhPOcg==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-active-header-links/-/plugin-active-header-links-2.0.0-beta.36.tgz",
+      "integrity": "sha512-jeH1sieF1M/2M33JoUXe5RuRcdlGvUqMIq2wGdnwfXZn7YzcZtM8bmmhgpZw5yTuW6mT59b5SwEINptkZDKtUw==",
       "dev": true,
       "requires": {
         "@vuepress/client": "2.0.0-beta.35",
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "@vuepress/utils": "2.0.0-beta.35",
         "ts-debounce": "^4.0.0",
         "vue": "^3.2.28",
@@ -1447,26 +1447,26 @@
       }
     },
     "@vuepress/plugin-back-to-top": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-2.0.0-beta.35.tgz",
-      "integrity": "sha512-8gAZBZhUML9/nNXirInI7qZhQkIeTrqp30IcpteoyFWCOM8XAE5I9zH7PxG5zNm4YN0k5WkLK0VICybPODyjEA==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-back-to-top/-/plugin-back-to-top-2.0.0-beta.36.tgz",
+      "integrity": "sha512-BwWa/EeKvboG22m4HmnCEfs/RcPtQ5pL5uVss8+POLgDSICKDGhuHrQiH/DtgqbceXZCryNlJhLkNXQ6TxcR+A==",
       "dev": true,
       "requires": {
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "@vuepress/utils": "2.0.0-beta.35",
         "ts-debounce": "^4.0.0",
         "vue": "^3.2.28"
       }
     },
     "@vuepress/plugin-container": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-container/-/plugin-container-2.0.0-beta.35.tgz",
-      "integrity": "sha512-cfkeOLg1FciVJgJIw9M+SRQ2qSwnW8J2/nmW19W8SGg9PdADIfnfHjVWKeSno3Y6RgA0v94fbnWEyC5MLp0wwA==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-container/-/plugin-container-2.0.0-beta.36.tgz",
+      "integrity": "sha512-65DjPd2RHnbk8wvyPimalC7K+dHbb41fWH8bPdJL6EhFPBCdplXmDHjR8sLU/15HGrF8ms8PRJ0nKRv5WUEsrw==",
       "dev": true,
       "requires": {
         "@types/markdown-it": "^12.2.3",
-        "@vuepress/core": "2.0.0-beta.35",
-        "@vuepress/markdown": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
+        "@vuepress/markdown": "2.0.0-beta.36",
         "@vuepress/shared": "2.0.0-beta.35",
         "@vuepress/utils": "2.0.0-beta.35",
         "markdown-it": "^12.3.2",
@@ -1474,49 +1474,49 @@
       }
     },
     "@vuepress/plugin-external-link-icon": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-external-link-icon/-/plugin-external-link-icon-2.0.0-beta.35.tgz",
-      "integrity": "sha512-CRXxtv4yQu29s4MQysN1e0gZn5wzl7o5fmzxn6YcZLY6UfEH9vYTyxM+YWyIdekHsHfz5JM0zDghZ5ds2lvJKQ==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-external-link-icon/-/plugin-external-link-icon-2.0.0-beta.36.tgz",
+      "integrity": "sha512-t8UHhvxT7Zwwv+bV+jKZ1fnTKxk6FHOQ9ydGnGWje7YTL097FppSrWFdMRFVTWBfqRKkrSOx5gB2LIz2pELWvA==",
       "dev": true,
       "requires": {
         "@vuepress/client": "2.0.0-beta.35",
-        "@vuepress/core": "2.0.0-beta.35",
-        "@vuepress/markdown": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
+        "@vuepress/markdown": "2.0.0-beta.36",
         "@vuepress/utils": "2.0.0-beta.35",
         "vue": "^3.2.28"
       }
     },
     "@vuepress/plugin-git": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-beta.35.tgz",
-      "integrity": "sha512-XBqEMlKO8SXIttJy0ughodsI40AbCeFZkS6WmmX1IfUzL/yPVzcIMKaTzNzza2YYt7qBjrJspApzBQhCqMof/g==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-beta.36.tgz",
+      "integrity": "sha512-Q2fIaExIZTZHWcJzelRMSf41yvfLUto2vFB9sMmpgRZ+vqFpPwruyR7XGmBxHMiSIjBFPbjAPadgB3hpoDKyiQ==",
       "dev": true,
       "requires": {
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "execa": "^5.1.1"
       }
     },
     "@vuepress/plugin-medium-zoom": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-medium-zoom/-/plugin-medium-zoom-2.0.0-beta.35.tgz",
-      "integrity": "sha512-AnBSCOWkd6juBwlEKESftk+UWOxJPYbdSEW/u4MuKtCaahcR9O4R2ZcSmH5O6mpl/MzOP02Ac0h5+UIsSHzZ2g==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-medium-zoom/-/plugin-medium-zoom-2.0.0-beta.36.tgz",
+      "integrity": "sha512-5qarMKNvypwYgo/ojOGSAKqug9mlmkzzaHGqX9w2rObYB0kCyV1CuqFOqd0Eg/3vif3B0fDOVgEIomjvgc8rQw==",
       "dev": true,
       "requires": {
         "@vuepress/client": "2.0.0-beta.35",
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "@vuepress/utils": "2.0.0-beta.35",
         "medium-zoom": "^1.0.6",
         "vue": "^3.2.28"
       }
     },
     "@vuepress/plugin-nprogress": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-2.0.0-beta.35.tgz",
-      "integrity": "sha512-Biu/91xG7FGr3OWyWXC5CKdJgcA8dxBaq1Q+MicvWo/9Og7kXfOSI5z0o6DVuGbFULfkctb2UJj/NT7xYW/2PA==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-2.0.0-beta.36.tgz",
+      "integrity": "sha512-PFDFdvWQvvkGCiYi2jiCiRggP984yAYyZtSuK9eX3A9itYi0Qp+ck10tc+7cGQc1B97zg3FHVyA0BJcXUJwiJQ==",
       "dev": true,
       "requires": {
         "@vuepress/client": "2.0.0-beta.35",
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "@vuepress/utils": "2.0.0-beta.35",
         "nprogress": "^0.2.0",
         "vue": "^3.2.28",
@@ -1524,35 +1524,35 @@
       }
     },
     "@vuepress/plugin-palette": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-palette/-/plugin-palette-2.0.0-beta.35.tgz",
-      "integrity": "sha512-VSZSWbttnW2jF9AMsvpfBA63sP+bFvKuFCP8Uwfc6FLJaav1CConrrMYi1y0RmU0BmVsJzWYkaMmiUALA/cQKw==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-palette/-/plugin-palette-2.0.0-beta.36.tgz",
+      "integrity": "sha512-37D1uwX1j91niSu6f//26azS18FSD3g93NJs8LM3HAim4XtzCRaFSnI90MNG2++4Aelx2SSx86M4OjVdb1oCKw==",
       "dev": true,
       "requires": {
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "@vuepress/utils": "2.0.0-beta.35",
         "chokidar": "^3.5.3"
       }
     },
     "@vuepress/plugin-prismjs": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-prismjs/-/plugin-prismjs-2.0.0-beta.35.tgz",
-      "integrity": "sha512-MIjofK5OEiSy6yPPGBNWp4YZezJB1sF7hzFi945ts3P6XXTBt1LctjzvVvQumNCRYYB+tsd3ge8+EzAQtznGXQ==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-prismjs/-/plugin-prismjs-2.0.0-beta.36.tgz",
+      "integrity": "sha512-xQ+Qa8ODt3K5blEZa2THTmXFO5/RrBjAgkk0u1JmPdVB8FoQAjdSaxZIs9vTBwCMCIexd6c3cC+MaPT2OVrgdA==",
       "dev": true,
       "requires": {
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "prismjs": "^1.26.0"
       }
     },
     "@vuepress/plugin-theme-data": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-theme-data/-/plugin-theme-data-2.0.0-beta.35.tgz",
-      "integrity": "sha512-iFVus6jbKk/BgBFMU3Xf1VQiCo89Tz6j5P67m1Xj7maTfCKxKOBfjxdVLBx6oLAY8WC19pcpeWXigqcKXMvzjA==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-theme-data/-/plugin-theme-data-2.0.0-beta.36.tgz",
+      "integrity": "sha512-1Fxj7F0rIARYa/gQmsUql3f7wPF3ML4Fs6kcPHXYll7ZNDLR1OBw9HIGJ7lW4qx37f6YfYs2RjefAuwkVFUn/A==",
       "dev": true,
       "requires": {
         "@vue/devtools-api": "^6.0.0-beta.21.1",
         "@vuepress/client": "2.0.0-beta.35",
-        "@vuepress/core": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
         "@vuepress/shared": "2.0.0-beta.35",
         "@vuepress/utils": "2.0.0-beta.35",
         "vue": "^3.2.28"
@@ -1568,23 +1568,23 @@
       }
     },
     "@vuepress/theme-default": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-2.0.0-beta.35.tgz",
-      "integrity": "sha512-g30Pur96tz1w1lRtUxJzF3J8/QYJL+o2ACuGinZ0GuBlcLXmbD1enqxTf/Ie9skd049YLEYb9LITG3MDPLjtWg==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/@vuepress/theme-default/-/theme-default-2.0.0-beta.36.tgz",
+      "integrity": "sha512-3QqRL96MzKDamHo5bw9ldO2DHTxE+nwEHv1u2PsZusyMRoxyP1h2wPFHPhGaR+fhxFC9Ou9dOq4Ay2xiIU1piA==",
       "dev": true,
       "requires": {
         "@vuepress/client": "2.0.0-beta.35",
-        "@vuepress/core": "2.0.0-beta.35",
-        "@vuepress/plugin-active-header-links": "2.0.0-beta.35",
-        "@vuepress/plugin-back-to-top": "2.0.0-beta.35",
-        "@vuepress/plugin-container": "2.0.0-beta.35",
-        "@vuepress/plugin-external-link-icon": "2.0.0-beta.35",
-        "@vuepress/plugin-git": "2.0.0-beta.35",
-        "@vuepress/plugin-medium-zoom": "2.0.0-beta.35",
-        "@vuepress/plugin-nprogress": "2.0.0-beta.35",
-        "@vuepress/plugin-palette": "2.0.0-beta.35",
-        "@vuepress/plugin-prismjs": "2.0.0-beta.35",
-        "@vuepress/plugin-theme-data": "2.0.0-beta.35",
+        "@vuepress/core": "2.0.0-beta.36",
+        "@vuepress/plugin-active-header-links": "2.0.0-beta.36",
+        "@vuepress/plugin-back-to-top": "2.0.0-beta.36",
+        "@vuepress/plugin-container": "2.0.0-beta.36",
+        "@vuepress/plugin-external-link-icon": "2.0.0-beta.36",
+        "@vuepress/plugin-git": "2.0.0-beta.36",
+        "@vuepress/plugin-medium-zoom": "2.0.0-beta.36",
+        "@vuepress/plugin-nprogress": "2.0.0-beta.36",
+        "@vuepress/plugin-palette": "2.0.0-beta.36",
+        "@vuepress/plugin-prismjs": "2.0.0-beta.36",
+        "@vuepress/plugin-theme-data": "2.0.0-beta.36",
         "@vuepress/shared": "2.0.0-beta.35",
         "@vuepress/utils": "2.0.0-beta.35",
         "@vueuse/core": "^7.5.4",
@@ -1625,19 +1625,19 @@
       }
     },
     "@vueuse/core": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-7.5.5.tgz",
-      "integrity": "sha512-RBDqmIoGfak4h3xdXa/Av+ibkb8NY044wEy6+PG2FAWNaID8/FkqmSFjbxogrbmpSX1yZ1PBHrM8DUp/FrIpbg==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-7.7.0.tgz",
+      "integrity": "sha512-DS8+dg758CiWnswebYHjS05PqTtc1ZLomsDlkFjG/KC0iFRgFIsGC66AAGuSXLqWCoirp2xN6N2mkrp1aHdI7A==",
       "dev": true,
       "requires": {
-        "@vueuse/shared": "7.5.5",
+        "@vueuse/shared": "7.7.0",
         "vue-demi": "*"
       }
     },
     "@vueuse/shared": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-7.5.5.tgz",
-      "integrity": "sha512-mzzTsotHQRPnPAChy8iCv6ek/90CKYhAFyMRgNsMxpT0afZJkbMO/X0OaOu/1NuGbgb8UVjlsWKmCUgKTOF5hA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-7.7.0.tgz",
+      "integrity": "sha512-ANzMcUnjuUPJ9nWqMAqYt8p0qon6AH5pP5/V/0RSWkwCIWZwi57ujIaxizzMwnJECUF/73BmsRmpvvtokCIrKw==",
       "dev": true,
       "requires": {
         "vue-demi": "*"
@@ -1781,34 +1781,34 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.19.1",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-          "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+          "version": "4.19.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
+          "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001286",
-            "electron-to-chromium": "^1.4.17",
+            "caniuse-lite": "^1.0.30001312",
+            "electron-to-chromium": "^1.4.71",
             "escalade": "^3.1.1",
-            "node-releases": "^2.0.1",
+            "node-releases": "^2.0.2",
             "picocolors": "^1.0.0"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001306",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
-          "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
+          "version": "1.0.30001312",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
+          "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.4.63",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.63.tgz",
-          "integrity": "sha512-e0PX/LRJPFRU4kzJKLvTobxyFdnANCvcoDCe8XcyTqP58nTWIwdsHvXLIl1RkB39X5yaosLaroMASWB0oIsgCA==",
+          "version": "1.4.75",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
+          "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
           "dev": true
         },
         "node-releases": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-          "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+          "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
           "dev": true
         }
       }
@@ -2416,146 +2416,162 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
-      "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.23.tgz",
+      "integrity": "sha512-XjnIcZ9KB6lfonCa+jRguXyRYcldmkyZ99ieDksqW/C8bnyEX299yA4QH2XcgijCgaddEZePPTgvx/2imsq7Ig==",
       "dev": true,
       "requires": {
-        "esbuild-android-arm64": "0.13.15",
-        "esbuild-darwin-64": "0.13.15",
-        "esbuild-darwin-arm64": "0.13.15",
-        "esbuild-freebsd-64": "0.13.15",
-        "esbuild-freebsd-arm64": "0.13.15",
-        "esbuild-linux-32": "0.13.15",
-        "esbuild-linux-64": "0.13.15",
-        "esbuild-linux-arm": "0.13.15",
-        "esbuild-linux-arm64": "0.13.15",
-        "esbuild-linux-mips64le": "0.13.15",
-        "esbuild-linux-ppc64le": "0.13.15",
-        "esbuild-netbsd-64": "0.13.15",
-        "esbuild-openbsd-64": "0.13.15",
-        "esbuild-sunos-64": "0.13.15",
-        "esbuild-windows-32": "0.13.15",
-        "esbuild-windows-64": "0.13.15",
-        "esbuild-windows-arm64": "0.13.15"
+        "esbuild-android-arm64": "0.14.23",
+        "esbuild-darwin-64": "0.14.23",
+        "esbuild-darwin-arm64": "0.14.23",
+        "esbuild-freebsd-64": "0.14.23",
+        "esbuild-freebsd-arm64": "0.14.23",
+        "esbuild-linux-32": "0.14.23",
+        "esbuild-linux-64": "0.14.23",
+        "esbuild-linux-arm": "0.14.23",
+        "esbuild-linux-arm64": "0.14.23",
+        "esbuild-linux-mips64le": "0.14.23",
+        "esbuild-linux-ppc64le": "0.14.23",
+        "esbuild-linux-riscv64": "0.14.23",
+        "esbuild-linux-s390x": "0.14.23",
+        "esbuild-netbsd-64": "0.14.23",
+        "esbuild-openbsd-64": "0.14.23",
+        "esbuild-sunos-64": "0.14.23",
+        "esbuild-windows-32": "0.14.23",
+        "esbuild-windows-64": "0.14.23",
+        "esbuild-windows-arm64": "0.14.23"
       }
     },
     "esbuild-android-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
-      "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.23.tgz",
+      "integrity": "sha512-k9sXem++mINrZty1v4FVt6nC5BQCFG4K2geCIUUqHNlTdFnuvcqsY7prcKZLFhqVC1rbcJAr9VSUGFL/vD4vsw==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
-      "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.23.tgz",
+      "integrity": "sha512-lB0XRbtOYYL1tLcYw8BoBaYsFYiR48RPrA0KfA/7RFTr4MV7Bwy/J4+7nLsVnv9FGuQummM3uJ93J3ptaTqFug==",
       "dev": true,
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
-      "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.23.tgz",
+      "integrity": "sha512-yat73Z/uJ5tRcfRiI4CCTv0FSnwErm3BJQeZAh+1tIP0TUNh6o+mXg338Zl5EKChD+YGp6PN+Dbhs7qa34RxSw==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
-      "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.23.tgz",
+      "integrity": "sha512-/1xiTjoLuQ+LlbfjJdKkX45qK/M7ARrbLmyf7x3JhyQGMjcxRYVR6Dw81uH3qlMHwT4cfLW4aEVBhP1aNV7VsA==",
       "dev": true,
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
-      "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.23.tgz",
+      "integrity": "sha512-uyPqBU/Zcp6yEAZS4LKj5jEE0q2s4HmlMBIPzbW6cTunZ8cyvjG6YWpIZXb1KK3KTJDe62ltCrk3VzmWHp+iLg==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
-      "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.23.tgz",
+      "integrity": "sha512-37R/WMkQyUfNhbH7aJrr1uCjDVdnPeTHGeDhZPUNhfoHV0lQuZNCKuNnDvlH/u/nwIYZNdVvz1Igv5rY/zfrzQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
-      "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.23.tgz",
+      "integrity": "sha512-H0gztDP60qqr8zoFhAO64waoN5yBXkmYCElFklpd6LPoobtNGNnDe99xOQm28+fuD75YJ7GKHzp/MLCLhw2+vQ==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
-      "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.23.tgz",
+      "integrity": "sha512-x64CEUxi8+EzOAIpCUeuni0bZfzPw/65r8tC5cy5zOq9dY7ysOi5EVQHnzaxS+1NmV+/RVRpmrzGw1QgY2Xpmw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
-      "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.23.tgz",
+      "integrity": "sha512-c4MLOIByNHR55n3KoYf9hYDfBRghMjOiHLaoYLhkQkIabb452RWi+HsNgB41sUpSlOAqfpqKPFNg7VrxL3UX9g==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
-      "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.23.tgz",
+      "integrity": "sha512-kHKyKRIAedYhKug2EJpyJxOUj3VYuamOVA1pY7EimoFPzaF3NeY7e4cFBAISC/Av0/tiV0xlFCt9q0HJ68IBIw==",
       "dev": true,
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
-      "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.23.tgz",
+      "integrity": "sha512-7ilAiJEPuJJnJp/LiDO0oJm5ygbBPzhchJJh9HsHZzeqO+3PUzItXi+8PuicY08r0AaaOe25LA7sGJ0MzbfBag==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.23.tgz",
+      "integrity": "sha512-fbL3ggK2wY0D8I5raPIMPhpCvODFE+Bhb5QGtNP3r5aUsRR6TQV+ZBXIaw84iyvKC8vlXiA4fWLGhghAd/h/Zg==",
+      "dev": true,
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.23.tgz",
+      "integrity": "sha512-GHMDCyfy7+FaNSO8RJ8KCFsnax8fLUsOrj9q5Gi2JmZMY0Zhp75keb5abTFCq2/Oy6KVcT0Dcbyo/bFb4rIFJA==",
       "dev": true,
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
-      "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.23.tgz",
+      "integrity": "sha512-ovk2EX+3rrO1M2lowJfgMb/JPN1VwVYrx0QPUyudxkxLYrWeBxDKQvc6ffO+kB4QlDyTfdtAURrVzu3JeNdA2g==",
       "dev": true,
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
-      "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.23.tgz",
+      "integrity": "sha512-uYYNqbVR+i7k8ojP/oIROAHO9lATLN7H2QeXKt2H310Fc8FJj4y3Wce6hx0VgnJ4k1JDrgbbiXM8rbEgQyg8KA==",
       "dev": true,
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
-      "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.23.tgz",
+      "integrity": "sha512-hAzeBeET0+SbScknPzS2LBY6FVDpgE+CsHSpe6CEoR51PApdn2IB0SyJX7vGelXzlyrnorM4CAsRyb9Qev4h9g==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
-      "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.23.tgz",
+      "integrity": "sha512-Kttmi3JnohdaREbk6o9e25kieJR379TsEWF0l39PQVHXq3FR6sFKtVPgY8wk055o6IB+rllrzLnbqOw/UV60EA==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
-      "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.23.tgz",
+      "integrity": "sha512-JtIT0t8ymkpl6YlmOl6zoSWL5cnCgyLaBdf/SiU/Eg3C13r0NbHZWNT/RDEMKK91Y6t79kTs3vyRcNZbfu5a8g==",
       "dev": true,
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.13.15",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
-      "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+      "version": "0.14.23",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.23.tgz",
+      "integrity": "sha512-cTFaQqT2+ik9e4hePvYtRZQ3pqOvKDVNarzql0VFIzhc0tru/ZgdLoXd6epLiKT+SzoSce6V9YJ+nn6RCn6SHw==",
       "dev": true,
       "optional": true
     },
@@ -3022,15 +3038,15 @@
       "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "fraction.js": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.2.tgz",
-      "integrity": "sha512-o2RiJQ6DZaR/5+Si0qJUIy637QMRudSi9kU/FFzx9EZazrIdnBgpU+3sEWCxAVhH2RtxW2Oz+T4p2o8uOPVcgA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.3.tgz",
+      "integrity": "sha512-pUHWWt6vHzZZiQJcM6S/0PXfS+g6FM4BF5rj9wZyreivhQPdsh5PpE25VtSNxq80wHS5RfY51Ii+8Z0Zl/pmzg==",
       "dev": true
     },
     "fs-extra": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
-      "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+      "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
@@ -5062,9 +5078,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
+      "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
     "natural-compare": {
@@ -5296,12 +5312,12 @@
       }
     },
     "postcss": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
-      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.7.tgz",
+      "integrity": "sha512-L9Ye3r6hkkCeOETQX6iOaWZgjp3LL6Lpqm6EtgbKrgqGGteRMNb9vzBfRL96YOSu8o7x3MfIH9Mo5cPJFGrW6A==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.2.0",
+        "nanoid": "^3.3.1",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -5346,9 +5362,9 @@
       }
     },
     "prismjs": {
-      "version": "1.26.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.26.0.tgz",
-      "integrity": "sha512-HUoH9C5Z3jKkl3UunCyiD5jwk0+Hz0fIgQ2nbwU2Oo/ceuTAQAg+pPVnfdt2TJWRVLcxKh9iuoYDUSc8clb5UQ==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
       "dev": true
     },
     "progress": {
@@ -5493,9 +5509,9 @@
       }
     },
     "rollup": {
-      "version": "2.67.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.67.0.tgz",
-      "integrity": "sha512-W83AaERwvDiHwHEF/dfAfS3z1Be5wf7n+pO3ZAO5IQadCT2lBTr7WQ2MwZZe+nodbD+n3HtC4OCOAdsOPPcKZQ==",
+      "version": "2.68.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.68.0.tgz",
+      "integrity": "sha512-XrMKOYK7oQcTio4wyTz466mucnd8LzkiZLozZ4Rz0zQD+HeX4nUK4B8GrTX/2EvN2/vBF/i2WnaXboPxo0JylA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -5522,9 +5538,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.49.7",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.7.tgz",
-      "integrity": "sha512-13dml55EMIR2rS4d/RDHHP0sXMY3+30e1TKsyXaSz3iLWVoDWEoboY8WzJd5JMnxrRHffKO3wq2mpJ0jxRJiEQ==",
+      "version": "1.49.9",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
+      "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -5533,9 +5549,9 @@
       }
     },
     "sass-loader": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.4.0.tgz",
-      "integrity": "sha512-7xN+8khDIzym1oL9XyS6zP6Ges+Bo2B2xbPrjdMHEYyV3AQYhd/wXeru++3ODHF0zMjYmVadblSKrPrjEkL8mg==",
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-12.6.0.tgz",
+      "integrity": "sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==",
       "dev": true,
       "requires": {
         "klona": "^2.0.4",
@@ -5773,6 +5789,12 @@
         "supports-color": "^7.0.0"
       }
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -6003,16 +6025,38 @@
       }
     },
     "vite": {
-      "version": "2.7.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.7.13.tgz",
-      "integrity": "sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.8.6.tgz",
+      "integrity": "sha512-e4H0QpludOVKkmOsRyqQ7LTcMUDF3mcgyNU4lmi0B5JUbe0ZxeBBl8VoZ8Y6Rfn9eFKYtdXNPcYK97ZwH+K2ug==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.13.12",
+        "esbuild": "^0.14.14",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.5",
-        "resolve": "^1.20.0",
+        "postcss": "^8.4.6",
+        "resolve": "^1.22.0",
         "rollup": "^2.59.0"
+      },
+      "dependencies": {
+        "is-core-module": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+          "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+          "dev": true,
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "1.22.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+          "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.8.1",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        }
       }
     },
     "vscode-oniguruma": {
@@ -6028,16 +6072,16 @@
       "dev": true
     },
     "vue": {
-      "version": "3.2.29",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.29.tgz",
-      "integrity": "sha512-cFIwr7LkbtCRanjNvh6r7wp2yUxfxeM2yPpDQpAfaaLIGZSrUmLbNiSze9nhBJt5MrZ68Iqt0O5scwAMEVxF+Q==",
+      "version": "3.2.31",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.31.tgz",
+      "integrity": "sha512-odT3W2tcffTiQCy57nOT93INw1auq5lYLLYtWpPYQQYQOOdHiqFct9Xhna6GJ+pJQaF67yZABraH47oywkJgFw==",
       "dev": true,
       "requires": {
-        "@vue/compiler-dom": "3.2.29",
-        "@vue/compiler-sfc": "3.2.29",
-        "@vue/runtime-dom": "3.2.29",
-        "@vue/server-renderer": "3.2.29",
-        "@vue/shared": "3.2.29"
+        "@vue/compiler-dom": "3.2.31",
+        "@vue/compiler-sfc": "3.2.31",
+        "@vue/runtime-dom": "3.2.31",
+        "@vue/server-renderer": "3.2.31",
+        "@vue/shared": "3.2.31"
       }
     },
     "vue-demi": {
@@ -6047,42 +6091,186 @@
       "dev": true
     },
     "vue-router": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.12.tgz",
-      "integrity": "sha512-CPXvfqe+mZLB1kBWssssTiWg4EQERyqJZes7USiqfW9B5N2x+nHlnsM1D3b5CaJ6qgCvMmYJnz+G0iWjNCvXrg==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.13.tgz",
+      "integrity": "sha512-LmXrC+BkDRLak+d5xTMgUYraT3Nj0H/vCbP+7usGvIl9Viqd1UP6AsP0i69pSbn9O0dXK/xCdp4yPw21HqV9Jw==",
       "dev": true,
       "requires": {
-        "@vue/devtools-api": "^6.0.0-beta.18"
+        "@vue/devtools-api": "^6.0.0"
       }
     },
     "vuepress": {
-      "version": "2.0.0-beta.35",
-      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-2.0.0-beta.35.tgz",
-      "integrity": "sha512-WMuL1s7DeyWRBFaByYMDSF4n9K/asLQXW1OJL9yxyTFmTl/VGs3llEjBqwbLhSmktz2lBlq67RtDLjVTE8PJPA==",
+      "version": "2.0.0-beta.36",
+      "resolved": "https://registry.npmjs.org/vuepress/-/vuepress-2.0.0-beta.36.tgz",
+      "integrity": "sha512-EObFjxn91cMRZ+9cgDGjKaTHaCH4NChMqUIGRnPTrIlJfKa4eX4aS0GzPtHSy+L1fKgNnDyUq67fW8q3hrHVjA==",
       "dev": true,
       "requires": {
-        "vuepress-vite": "2.0.0-beta.35"
+        "vuepress-vite": "2.0.0-beta.36"
       },
       "dependencies": {
-        "vuepress-vite": {
-          "version": "2.0.0-beta.35",
-          "resolved": "https://registry.npmjs.org/vuepress-vite/-/vuepress-vite-2.0.0-beta.35.tgz",
-          "integrity": "sha512-gN7DbhZLdoFxK2Yv9ao+51IfcmjuIEGigwrT8gfdOMBGTRCTkxYgiSQsS5IbwN+aXxA2VJLBAcCdrgk1miAMRQ==",
+        "esbuild": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+          "integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
           "dev": true,
           "requires": {
-            "@vuepress/bundler-vite": "2.0.0-beta.35",
-            "@vuepress/cli": "2.0.0-beta.35",
-            "@vuepress/core": "2.0.0-beta.35",
-            "@vuepress/theme-default": "2.0.0-beta.35"
+            "esbuild-android-arm64": "0.13.15",
+            "esbuild-darwin-64": "0.13.15",
+            "esbuild-darwin-arm64": "0.13.15",
+            "esbuild-freebsd-64": "0.13.15",
+            "esbuild-freebsd-arm64": "0.13.15",
+            "esbuild-linux-32": "0.13.15",
+            "esbuild-linux-64": "0.13.15",
+            "esbuild-linux-arm": "0.13.15",
+            "esbuild-linux-arm64": "0.13.15",
+            "esbuild-linux-mips64le": "0.13.15",
+            "esbuild-linux-ppc64le": "0.13.15",
+            "esbuild-netbsd-64": "0.13.15",
+            "esbuild-openbsd-64": "0.13.15",
+            "esbuild-sunos-64": "0.13.15",
+            "esbuild-windows-32": "0.13.15",
+            "esbuild-windows-64": "0.13.15",
+            "esbuild-windows-arm64": "0.13.15"
+          }
+        },
+        "esbuild-android-arm64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+          "integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-darwin-64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+          "integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-darwin-arm64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+          "integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-freebsd-64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+          "integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-freebsd-arm64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+          "integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-32": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+          "integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+          "integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-arm": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+          "integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-arm64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+          "integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-mips64le": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+          "integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-linux-ppc64le": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+          "integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-netbsd-64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+          "integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-openbsd-64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+          "integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-sunos-64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+          "integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-32": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+          "integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+          "integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+          "dev": true,
+          "optional": true
+        },
+        "esbuild-windows-arm64": {
+          "version": "0.13.15",
+          "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+          "integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+          "dev": true,
+          "optional": true
+        },
+        "vuepress-vite": {
+          "version": "2.0.0-beta.36",
+          "resolved": "https://registry.npmjs.org/vuepress-vite/-/vuepress-vite-2.0.0-beta.36.tgz",
+          "integrity": "sha512-KbN7HDhaCLVB7/YmJDydQClUjMBybLtBpB376mi5fD16RFBzHwMGI7zopb4lu7Nmj2BnvLI9kpottv9zuOJYLQ==",
+          "dev": true,
+          "requires": {
+            "@vuepress/bundler-vite": "2.0.0-beta.36",
+            "@vuepress/cli": "2.0.0-beta.36",
+            "@vuepress/core": "2.0.0-beta.36",
+            "@vuepress/theme-default": "2.0.0-beta.36"
           },
           "dependencies": {
             "@vuepress/cli": {
-              "version": "2.0.0-beta.35",
-              "resolved": "https://registry.npmjs.org/@vuepress/cli/-/cli-2.0.0-beta.35.tgz",
-              "integrity": "sha512-m+BfO2z4C/MlqE+QBBRvgaMk9eUESMca+3XXaXl3l6ciHZ/pZOeDodMCZpiVeNpWbQT5qNNnt1DITyWlF6DyMw==",
+              "version": "2.0.0-beta.36",
+              "resolved": "https://registry.npmjs.org/@vuepress/cli/-/cli-2.0.0-beta.36.tgz",
+              "integrity": "sha512-tGhC4OgdgOOoXGw79HFAJz5y9t9YRNdSsgkMRJvCAv9f257X+M/Ex/Qh3hfcnge+OBuMj63JLDB0FDRQWeJFUA==",
               "dev": true,
               "requires": {
-                "@vuepress/core": "2.0.0-beta.35",
+                "@vuepress/core": "2.0.0-beta.36",
                 "@vuepress/utils": "2.0.0-beta.35",
                 "cac": "^6.7.12",
                 "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ts-jest": "^27.0.4",
     "typedoc": "^0.22.11",
     "typescript": "^4.3.5",
-    "vuepress": "^2.0.0-beta.35"
+    "vuepress": "^2.0.0-beta.36"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
Update Vuepress to `2.0.0-beta.36` to get rid of transient dependency vulnerability in Prismjs.

Given that Vuepress has been the source of transient dependency vulnerabilities for this package, we should consider removing Vuepress from dev-dependencies and instead use `npx vuepress ...` in our build step.

Fixes #62.
