### PR TITLE
Final changes for release v0.3.0

### DIFF
--- a/docs/freshservice/tickets.md
+++ b/docs/freshservice/tickets.md
@@ -147,7 +147,7 @@ Restore a deleted Freshservice Ticket
 ```js
 // Restore ticket with given ticket ID
 const ticketId = 14000239432;
-const restoredTicket = await fs.tickets.restoreTicket(ticketId);
+const restoredTicket = await fs.tickets.restore(ticketId);
 // use restoredTicket.json() to access object elements
 ```
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -34,19 +34,6 @@ To use this library in a Freshworks app, add the following to the `"dependencies
 }
 ```
 
-#### Apps on platform-version 2.2
-
-For apps on platform-version up to `2.2`, allow the app to communicate with the domain for the product's REST API that you would be using (currently, only Freshteam and Freshservice). To do this, update the `"whitelisted-domains"` array in `manifest.json`:
-
-```js
-{
-  // ...
-  "whitelisted-domains": ["https://*.freshteam.com", "https://*.freshservice.com"]
-}
-```
-
-#### Running
-
 The Freshworks CLI (`fdk`) will fetch the dependency next time you run `fdk run`.
 
 ## Sample code

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "author": "Freshworks Inc",
   "license": "MIT",
-  "homepage": "https://freshworks.dev/api-sdk/",
+  "homepage": "https://developers.freshworks.com/api-sdk/",
   "repository": {
     "type": "git",
     "url": "https://github.com/freshworks/freshworks-api-sdk.git"

--- a/src/freshservice/tickets.js
+++ b/src/freshservice/tickets.js
@@ -69,7 +69,7 @@ export class TicketUtil {
    * @param {Number} id - ID of the ticket to be restored
    * @return {Promise<Response>} - returns a Promise
    */
-  async restoreTicket(id) {
+  async restore(id) {
     return this._api.restoreTicketWithHttpInfo(id).then(res => intoResponse(res));
   }
 

--- a/test/freshservice/ticket.test.js
+++ b/test/freshservice/ticket.test.js
@@ -95,7 +95,7 @@ describe("Tickets API Test Suite", function () {
     it("Restoring a ticket with given ticket ID", async function () {
       const ticket_id = 14000239432;
       mock.get(`/api/v2/tickets/${ticket_id}/restore`).reply(204);
-      const restoredTicket = await fs.tickets.restoreTicket(ticket_id);
+      const restoredTicket = await fs.tickets.restore(ticket_id);
       expect(restoredTicket).toBeNull;
     });
   });


### PR DESCRIPTION
- Change homepage url to `developers.freshworks.com`
- Rename `fs.tickets.restoreTicket(id)` to `fs.tickets.restore(id)`
- Remove info about whitelisted-domains from docs 